### PR TITLE
Standardize command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Usage:
     --regex="PATTERN"
             Only include files matching the given regex pattern
             (example: --regex="\.avi$")
-    -test=N
+    --test=N
             Use N seconds for the test encode
             (default: 5)
     --dry-run

--- a/README.md
+++ b/README.md
@@ -51,21 +51,44 @@ If the estimated encoded file is at least **20% smaller** than the original, it 
 
 ```bash
 Usage:
-  ./script.sh [arguments] <folder>
-    List of arguments :
-    -R              : Encode recursively inside subfolders
-    min=X.YZ        : Ignore files smaller than X.YZ GB
-    --regex="PATTERN"        Only include files matching the given regex pattern (e.g., --regex="\.avi$").
-    test=N          : Use N seconds for the test encode (default: 5)
-    --dry-run       : Only show compatible files without encoding
-    --keep-original : Keep original files instead of replacing them
-    --allow-h265    : Allow files already encoded in H.265
-    --allow-av1     : Allow files already encoded in AV1
-    -backup /path   : Save original files to backup path (used only if not using --keep-original)
-    --clean         : Remove temporary encoding files (.tmp_encode_*, .tmp_encode_test_*) from the folder(s, if combined with -R) 
-    --purge         : Remove encoded.list files (.tmp_encode_*, .tmp_encode_test_*) from the folder(s, if combined with -R) 
-    -h              : Show this help message
-    --stop-after HH.5  : Stop after HH.5 hours of encoding (useful if in cron)
+  ./h265-nvidia-batch-encoder.sh [options] <folder>
+
+    --recursive, -R
+            Encode recursively inside subfolders
+    --min=X
+            Ignore files smaller than X GB
+            (example: --min=1)
+            (example: --min=1.75)
+    --regex="PATTERN"
+            Only include files matching the given regex pattern
+            (example: --regex="\.avi$")
+    -test=N
+            Use N seconds for the test encode
+            (default: 5)
+    --dry-run
+            Only show compatible files without encoding
+    --keep-original
+            Keep original files instead of replacing them
+    --allow-h265
+            Allow files already encoded in H.265
+    --allow-av1
+            Allow files already encoded in AV1
+    --backup /path
+            Save original files to backup path
+            (only if not using --keep-original)
+    --clean
+            Remove temporary encoding files (.tmp_encode_*, .tmp_encode_test_*)
+            from the folder(s, if combined with -R)
+    --purge
+            Remove encoded.list files from the folder(s, if combined with -R)
+    --retry
+            Remove failed.list files from the folder(s, if combined with -R)
+    --help, -h
+            Show this help message
+    --stop-after=H
+            Stop after H hours of encoding (useful if in cron)
+            (example: --stop-after=5)
+            (example: --stop-after=5.5)
 
 ```
 ### How it will look

--- a/h265-nvidia-batch-encoder.sh
+++ b/h265-nvidia-batch-encoder.sh
@@ -1,28 +1,49 @@
 #!/bin/bash
 
 usage() {
-  echo "
+cat <<EOF
 Supported formats: .mkv .avi .mp4 .mov .wmv .flv
-This script re-encodes video files using hardware-accelerated HEVC (H.265) compression,
-optionally skipping already optimized files and ignoring small files.
+This script re-encodes video files using hardware-accelerated HEVC (H.265)
+compression, optionally skipping already optimized files and ignoring small
+files.
 
 Usage:
-  ./script.sh [-R] [min=X] [test=Y] [--dry-run] [--keep-original] [--allow-h265] [--allow-av1] [-backup /path] <folder>
-    -R              : Encode recursively inside subfolders
-    -min=X.YZ        : Ignore files smaller than X.YZ GB
-    --regex="PATTERN"        Only include files matching the given regex pattern (e.g., --regex="\.avi$").
-    -test=N          : Use N seconds for the test encode (default: 5)
-    --dry-run       : Only show compatible files without encoding
-    -keep-original : Keep original files instead of replacing them
-    -allow-h265    : Allow files already encoded in H.265
-    -allow-av1     : Allow files already encoded in AV1
-    -backup /path   : Save original files to backup path (used only if not using --keep-original)
-    --clean         : Remove temporary encoding files (.tmp_encode_*, .tmp_encode_test_*) from the folder(s, if combined with -R) 
-    --purge         : Remove encoded.list files from the folder(s, if combined with -R) 
-    --retry         : Remove failed.list files from the folder(s, if combined with -R) 
-    -h              : Show this help message
-    -stop-after HH.5  : Stop after HH.5 hours of encoding (useful if in cron)"
-  exit 0
+  ${0} [options] <folder>
+
+    -R
+            Encode recursively inside subfolders
+    -min=X.YZ
+            Ignore files smaller than X.YZ GB
+    --regex="PATTERN"
+            Only include files matching the given regex pattern
+            (example: --regex="\.avi$")
+    -test=N
+            Use N seconds for the test encode
+            (default: 5)
+    --dry-run
+            Only show compatible files without encoding
+    -keep-original
+            Keep original files instead of replacing them
+    -allow-h265
+            Allow files already encoded in H.265
+    -allow-av1
+            Allow files already encoded in AV1
+    -backup /path
+            Save original files to backup path
+            (only if not using --keep-original)
+    --clean
+            Remove temporary encoding files (.tmp_encode_*, .tmp_encode_test_*)
+            from the folder(s, if combined with -R)
+    --purge
+            Remove encoded.list files from the folder(s, if combined with -R)
+    --retry
+            Remove failed.list files from the folder(s, if combined with -R)
+    -h
+            Show this help message
+    -stop-after HH.5
+            Stop after HH.5 hours of encoding (useful if in cron)"
+EOF
+exit 0
 }
 
 

--- a/h265-nvidia-batch-encoder.sh
+++ b/h265-nvidia-batch-encoder.sh
@@ -43,7 +43,8 @@ Usage:
     -stop-after HH.5
             Stop after HH.5 hours of encoding (useful if in cron)"
 EOF
-exit 0
+# $1 is scoped to usage(), used as an exit-status value if provided.
+exit ${1}
 }
 
 
@@ -308,11 +309,12 @@ while [[ $# -gt 0 ]]; do
 	  -stop-after) STOP_AFTER_HOURS=$(echo "$2" | sed 's/,/./' | awk '{printf "%.0f", $1}'); shift 2 ;;
     -regex=*) REGEX_FILTER="${1#--regex=}" ; shift ;;
     -h) usage ;;
-    *) [[ -z "$FOLDER" ]] && FOLDER="$1" || usage; shift ;;
+    *) [[ -z "$FOLDER" ]] && FOLDER="$1" || usage 1; shift ;;
   esac
 done
 
-[[ -z "$FOLDER" || ! -d "$FOLDER" ]] && { echo "❌ Folder not found or not specified: $FOLDER"; exit 1; }
+[[   -z "$FOLDER" ]] && { echo -e "❌ Folder not specified.\n";   usage 1; }
+[[ ! -d "$FOLDER" ]] && { echo    "❌ Folder not found: $FOLDER"; exit  1; }
 
 
 # =====================

--- a/h265-nvidia-batch-encoder.sh
+++ b/h265-nvidia-batch-encoder.sh
@@ -23,7 +23,7 @@ Usage:
     --regex="PATTERN"
             Only include files matching the given regex pattern
             (example: --regex="\.avi$")
-    -test=N
+    --test=N
             Use N seconds for the test encode
             (default: 5)
     --dry-run

--- a/h265-nvidia-batch-encoder.sh
+++ b/h265-nvidia-batch-encoder.sh
@@ -296,7 +296,7 @@ echo "██   ██ ██████   ██████  █████�
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -R) RECURSIVE=1 ; shift ;;
-    min=*) raw_min="${1#min=}"; MIN_SIZE_BYTES=$(echo "$raw_min" | sed 's/,/./' | awk '{printf "%.0f", $1 * 1024 * 1024 * 1024}') ; shift ;;
+    min=*) raw_min="${1#min=}"; MIN_SIZE_BYTES=$(echo "$raw_min" | sed 's/,/./' | awk '{printf "%.2f", $1 * 1024 * 1024 * 1024}') ; shift ;;
     test=*) TEST_DURATION="${1#test=}"; TEST_DURATION=${TEST_DURATION%.*} ; shift ;;
     --dry-run) DRY_RUN=1 ; shift ;;
     -keep-original) KEEP_ORIGINAL=1 ; shift ;;
@@ -306,8 +306,8 @@ while [[ $# -gt 0 ]]; do
     --clean) CLEAN_ONLY=1 ; shift ;;
     --purge) PURGE_ONLY=1 ; shift ;;
     --retry) RETRY=1 ; shift ;;
-	  -stop-after) STOP_AFTER_HOURS=$(echo "$2" | sed 's/,/./' | awk '{printf "%.0f", $1}'); shift 2 ;;
-    -regex=*) REGEX_FILTER="${1#--regex=}" ; shift ;;
+	  -stop-after) STOP_AFTER_HOURS=$(echo "$2" | sed 's/,/./' | awk '{printf "%.2f", $1}'); shift 2 ;;
+    -regex=*) REGEX_FILTER="${1#-regex=}" ; shift ;;
     -h) usage ;;
     *) [[ -z "$FOLDER" ]] && FOLDER="$1" || usage 1; shift ;;
   esac

--- a/h265-nvidia-batch-encoder.sh
+++ b/h265-nvidia-batch-encoder.sh
@@ -435,14 +435,6 @@ fi
 
 
 ############################
-# Unit Coversions
-############################
-
-# MIN_SIZE_RAW may have been set via an arg.
-# Re-calculate it regardless.
-MIN_SIZE_BYTES=$(echo "$MIN_SIZE_RAW" | awk '{printf "%.0f", $1 * 1024 * 1024 * 1024}')
-
-############################
 # Startup
 ############################
 

--- a/h265-nvidia-batch-encoder.sh
+++ b/h265-nvidia-batch-encoder.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Enable extra globbing. Used in the case statement that parses the
+# command-line
+shopt -s extglob
+
 usage() {
 cat <<EOF
 Supported formats: .mkv .avi .mp4 .mov .wmv .flv
@@ -10,10 +14,12 @@ files.
 Usage:
   ${0} [options] <folder>
 
-    -R
+    --recursive, -R
             Encode recursively inside subfolders
-    -min=X.YZ
-            Ignore files smaller than X.YZ GB
+    --min=X
+            Ignore files smaller than X GB
+            (example: --min=1)
+            (example: --min=1.75)
     --regex="PATTERN"
             Only include files matching the given regex pattern
             (example: --regex="\.avi$")
@@ -22,13 +28,13 @@ Usage:
             (default: 5)
     --dry-run
             Only show compatible files without encoding
-    -keep-original
+    --keep-original
             Keep original files instead of replacing them
-    -allow-h265
+    --allow-h265
             Allow files already encoded in H.265
-    -allow-av1
+    --allow-av1
             Allow files already encoded in AV1
-    -backup /path
+    --backup /path
             Save original files to backup path
             (only if not using --keep-original)
     --clean
@@ -38,10 +44,12 @@ Usage:
             Remove encoded.list files from the folder(s, if combined with -R)
     --retry
             Remove failed.list files from the folder(s, if combined with -R)
-    -h
+    --help, -h
             Show this help message
-    -stop-after HH.5
-            Stop after HH.5 hours of encoding (useful if in cron)"
+    --stop-after=H
+            Stop after H hours of encoding (useful if in cron)
+            (example: --stop-after=5)
+            (example: --stop-after=5.5)
 EOF
 # $1 is scoped to usage(), used as an exit-status value if provided.
 exit ${1}
@@ -145,7 +153,7 @@ MIN_BYTE_PER_SEC=$((MIN_BITRATE * 1000 / 8))
 ##################
 offset_auto=0
 RECURSIVE=0
-raw_min=0
+MIN_SIZE_RAW=0
 MIN_SIZE_BYTES=0
 FOLDER=""
 DRY_RUN=0
@@ -295,21 +303,69 @@ echo "██   ██ ██████   ██████  █████�
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -R) RECURSIVE=1 ; shift ;;
-    min=*) raw_min="${1#min=}"; MIN_SIZE_BYTES=$(echo "$raw_min" | sed 's/,/./' | awk '{printf "%.2f", $1 * 1024 * 1024 * 1024}') ; shift ;;
-    test=*) TEST_DURATION="${1#test=}"; TEST_DURATION=${TEST_DURATION%.*} ; shift ;;
-    --dry-run) DRY_RUN=1 ; shift ;;
-    -keep-original) KEEP_ORIGINAL=1 ; shift ;;
-    -allow-h265) ALLOW_H265=1 ; shift ;;
-    -allow-av1) ALLOW_AV1=1 ; shift ;;
-    -backup) BACKUP_DIR="$2" ; shift 2 ;;
-    --clean) CLEAN_ONLY=1 ; shift ;;
-    --purge) PURGE_ONLY=1 ; shift ;;
-    --retry) RETRY=1 ; shift ;;
-	  -stop-after) STOP_AFTER_HOURS=$(echo "$2" | sed 's/,/./' | awk '{printf "%.2f", $1}'); shift 2 ;;
-    -regex=*) REGEX_FILTER="${1#-regex=}" ; shift ;;
-    -h) usage ;;
-    *) [[ -z "$FOLDER" ]] && FOLDER="$1" || usage 1; shift ;;
+    --recursive|-R)
+        RECURSIVE=1
+        shift ;;
+    --min=+([0-9.])|min=+([0-9.]))  # no-dash - for compatability with previous behaviour
+        MIN_SIZE_RAW=$(echo ${1#*min=} | awk '{printf "%.2f", $1}')
+        MIN_SIZE_BYTES=$(echo "$MIN_SIZE_RAW" | awk '{printf "%.0f", $1 * 1024 * 1024 * 1024}')
+        shift ;;
+    --test=+([0-9])|test=+([0-9]))  # no-dash - for compatability with previous behaviour
+        TEST_DURATION=$(echo ${1#*test=} | awk '{printf "%.0f", $1}')
+        shift ;;
+    --dry-run)
+        DRY_RUN=1
+        shift ;;
+    --keep-original|-keep-original) # single-dash - for compatability with previous behaviour
+        KEEP_ORIGINAL=1
+        shift ;;
+    --allow-h265|-allow-h265)       # single-dash - for compatability with previous behaviour
+        ALLOW_H265=1
+        shift ;;
+    --allow-av1|-allow-av1)         # single-dash - for compatability with previous behaviour
+        ALLOW_AV1=1
+        shift ;;
+    --backup=*)
+        BACKUP_DIR="${1#--backup=}"
+        shift ;;
+    -backup)                        # single-dash, two args - for compatability with previous behaviour
+        BACKUP_DIR="$2"
+        shift 2 ;;
+    --clean)
+        CLEAN_ONLY=1
+        shift ;;
+    --purge)
+        PURGE_ONLY=1
+        shift ;;
+    --retry)
+        RETRY=1
+        shift ;;
+    --stop-after=+([0-9.]))
+        STOP_AFTER_HOURS=$(echo "${1#--stop-after=}" | awk '{printf "%.2f", $1}')
+        shift ;;
+    -stop-after)                    # single-dash, two args - for compatability with previous behaviour
+        STOP_AFTER_HOURS=$(echo "$2" | sed 's/,/./' | awk '{printf "%.2f", $1}')
+        shift 2 ;;
+    --regex=*|-regex=*)             # single-dash - for compatability with previous behaviour
+        REGEX_FILTER="${1#*regex=}"
+        shift ;;
+    --help|-h)
+        usage 0
+        shift ;;
+    # Catch mal-formed arguments from above
+    # (such as not using =, incorrect characters, etc)
+    --min*|--test*|--regex|-regex)
+        echo -e "❌ Malformed argument: ${1}\n"
+        usage 1
+        shift ;;
+    *)
+        if [[ -z "$FOLDER" ]] then
+            FOLDER="${1}"
+        else
+            echo -e "❌ Bad Argument or too many folders provided: ${1}\n"
+            exit 1
+        fi
+        shift ;;
   esac
 done
 
@@ -377,6 +433,15 @@ if (( RETRY > 0 )); then
   exit 0
 fi
 
+
+############################
+# Unit Coversions
+############################
+
+# MIN_SIZE_RAW may have been set via an arg.
+# Re-calculate it regardless.
+MIN_SIZE_BYTES=$(echo "$MIN_SIZE_RAW" | awk '{printf "%.0f", $1 * 1024 * 1024 * 1024}')
+
 ############################
 # Startup
 ############################
@@ -402,7 +467,7 @@ print_config() {
 \e[1;33mFolder\e[0m                     ${FOLDER}
 \e[1;33mRecursive\e[0m                  ${RECURSIVE}
 \e[1;33mREGEX Filter\e[0m               ${REGEX_FILTER}
-\e[1;33mMinimum Size\e[0m               ${raw_min} GB
+\e[1;33mMinimum Size\e[0m               ${MIN_SIZE_RAW} GB
 \e[1;33mKeep original\e[0m              ${KEEP_ORIGINAL}
 \e[1;33mStop after\e[0m                 ${STOP_AFTER_HOURS}h
 \e[1;33mAllow H265\e[0m                 ${ALLOW_H265}


### PR DESCRIPTION
Attached is a pull request with the following fixes:

* Reformatting the `usage` output to fit in 80 characters (for tiled terminals). Styled after what you get from `sed --help`
* Showing `usage` if there is no folder provided
* Fixing `min=` and `-stop-after` to support two decimals (as the usage/README suggests) instead of rounding to an integer.
* Update all args to consistently use `--key=value` style args (specific changes summarized below). Note that the old-format args still work, so this shouldn't break any cron jobs.
  * While reworking the arg parsing, I also added a basic input filter for `--min=`, --test=`, and --stop-after=`. This is done in the case definition itself, which is possible with key=value style args. 
* Update README with new usage output.

Each change is a separate commit for easier review.

# Argument changes:

## Resolve Inconsistent number of dashes

* `min=X`, `test=X` : No dashes on args
* `-backup`, `-keep-original`, and others: one dash
* `--dry-run`, `--clean`, and others : two dashes
* `-regex="X"` used one dash in the case definition, but used two in the variable parsing.
* README used double-dashes for everything.

All values updated to use double-dashes (the old single/no dash versions still work)

## The format of args that take values had two different styles

* `min=X`, `test=X` : single arg with key=value
* `-backup X` : Two args, with separate key <space> value

Updated to `--backup=X`. As mentioned, the old `-backup X` will still work.